### PR TITLE
Disables pointer events on grid overlay

### DIFF
--- a/_column-setter.scss
+++ b/_column-setter.scss
@@ -394,6 +394,7 @@ $grid-lesson: "A 'grid' mixin call must include a valid class name, e.g. 'grid(c
 					width: 100%;
 					height: 100%;
 					z-index: 100;
+					pointer-events: none;
 					@each $bp, $value in $breakpoints {
 						@include breakpoint-min($bp) {
 							background-image: repeating-linear-gradient(


### PR DESCRIPTION
Allows clickthrough to elements on the page underneath the overlay (buttons, hovers, links, etc).